### PR TITLE
fix(kubectl): add pod running timeout of 5 minutes

### DIFF
--- a/src/kubectl-application-shell
+++ b/src/kubectl-application-shell
@@ -149,6 +149,7 @@ kubectl_run_cmd="kubectl run \
 --limits=$limits \
 --requests=$requests \
 --image=$image \
+--pod-running-timeout=5m \
 \"debug-$deployment-$RANDOM\" \
 --overrides='${overrides}'"
 


### PR DESCRIPTION
One minute is too low for Fargate, five minutes is more reasonable.